### PR TITLE
Update link to docs portal

### DIFF
--- a/getting-started-sdks.md
+++ b/getting-started-sdks.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-08-22"
+lastupdated: "2017-11-01"
 
 ---
 
@@ -30,7 +30,7 @@ The following {{site.data.keyword.watson}} SDKs are supported by {{site.data.key
 * [.NET SDK ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://github.com/watson-developer-cloud/dotnet-standard-sdk){: new_window}
 * [Unity SDK ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://github.com/watson-developer-cloud/unity-sdk){: new_window}
 
-The [API reference ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://console.{DomainName}/developer/watson/resources){: new_window} for each service includes information and examples for the Java, Node.js, and Python SDKs.
+The [API reference ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://console.{DomainName}/developer/watson/documentation){: new_window} for each service includes information and examples for the Java, Node.js, and Python SDKs.
 {: tip}
 
 ## Community SDKs

--- a/toc
+++ b/toc
@@ -33,7 +33,7 @@ Watson
     getting-started-variables.md
     getting-started-sdks.md
     [Watson GitHub repos](https://github.com/watson-developer-cloud/)
-    [Watson docs](https://console.bluemix.net/developer/watson/resources)
+    [Watson docs](https://console.bluemix.net/developer/watson/documentation)
     {: .navgroup-end}
 
     {: .navgroup id="help"}


### PR DESCRIPTION
Target changed. 
This updates the `Watson docs` link in the toc and the `API reference` tip in the SDKs page